### PR TITLE
Fix for Task Stop function

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -47,11 +47,11 @@ type Task struct {
 
 // Stop tells the goroutine to stop.
 func (t *Task) Stop() {
-        // When task is stopped from a different go-routine other than the one
-        // that actually started it.
-        t.lock.Lock()
+	// When task is stopped from a different go-routine other than the one
+	// that actually started it.
+	t.lock.Lock()
 	t.shouldStop = true
-        t.lock.Unlock()
+	t.lock.Unlock()
 }
 
 // StopChan gets the stop channel for this task.

--- a/runner.go
+++ b/runner.go
@@ -47,7 +47,11 @@ type Task struct {
 
 // Stop tells the goroutine to stop.
 func (t *Task) Stop() {
+        // When task is stopped from a different go-routine other than the one
+        // that actually started it.
+        t.lock.Lock()
 	t.shouldStop = true
+        t.lock.Unlock()
 }
 
 // StopChan gets the stop channel for this task.


### PR DESCRIPTION
Noticed there were race conditions when calling task.Stop. Need a lock before setting task.shouldStop
